### PR TITLE
Append rules at end of client-side stylesheet

### DIFF
--- a/utils/inject.js
+++ b/utils/inject.js
@@ -22,7 +22,7 @@ export const addCss = (id, text) => {
     rules[id].text = (rules[id]?.text || "") + text;
 
     if (styleSheet) {
-      styleSheet.insertRule(text);
+      styleSheet.insertRule(text, (Object.keys(rules).length-1));
     }
   }
 };


### PR DESCRIPTION
Added an explicit index to styleSheet.insertRule in inject.js so that the order of rules is consistent in the client side stylesheet as well as the server-side flush() created stylesheet. Without an index, the default is to prepend the rules, resulting in the reverse order of the flush() created stylesheet.

BTW, thank you so much for publishing react-native-media-query, it has helped the development of my components very much!