### PR TITLE
fix: @type/react-native dependency

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,7 @@
 import { DetailedReactHTMLElement } from "react";
 import { ViewStyle, TextStyle, ImageStyle } from "react-native";
 
-type NamedStyles<T> = { [P in keyof T]: ViewStyle | TextStyle | ImageStyle };
+export type NamedStyles<T> = { [P in keyof T]: ViewStyle | TextStyle | ImageStyle };
 
 export declare function create<
   UserStyles extends NamedStyles<UserStyles> | NamedStyles<any>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,51 @@
 {
   "name": "react-native-media-query",
-  "version": "1.0.2",
+  "version": "1.0.8",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/prop-types": {
+      "version": "15.7.4",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.4.tgz",
+      "integrity": "sha512-rZ5drC/jWjrArrS8BR6SIr4cWpW09RNTYt9AMZo3Jwwif+iacXAqgVjm0B0Bv/S1jhDXKHqRVNCbACkJ89RAnQ==",
+      "dev": true
+    },
+    "@types/react": {
+      "version": "17.0.27",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-17.0.27.tgz",
+      "integrity": "sha512-zgiJwtsggVGtr53MndV7jfiUESTqrbxOcBvwfe6KS/9bzaVPCTDieTWnFNecVNx6EAaapg5xsLLWFfHHR437AA==",
+      "dev": true,
+      "requires": {
+        "@types/prop-types": "*",
+        "@types/scheduler": "*",
+        "csstype": "^3.0.2"
+      }
+    },
+    "@types/react-native": {
+      "version": "0.65.5",
+      "resolved": "https://registry.npmjs.org/@types/react-native/-/react-native-0.65.5.tgz",
+      "integrity": "sha512-lc2JVmqVIkFmEtUHX8jCkuepqRSzlhRPBIlVFVc0hgfoUxvntrORhmK7LCnAbHfmpUqVVGhMjax27CCTACQ2Kw==",
+      "dev": true,
+      "requires": {
+        "@types/react": "*"
+      }
+    },
+    "@types/scheduler": {
+      "version": "0.16.2",
+      "resolved": "https://registry.npmjs.org/@types/scheduler/-/scheduler-0.16.2.tgz",
+      "integrity": "sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==",
+      "dev": true
+    },
     "css-mediaquery": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/css-mediaquery/-/css-mediaquery-0.1.2.tgz",
       "integrity": "sha1-aiw3NEkoYYYxxUvTPO3TAdoYvqA="
     },
-    "string-hash": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/string-hash/-/string-hash-1.1.3.tgz",
-      "integrity": "sha1-6Kr8CsGFW0Zmkp7X3RJ1311sgRs="
+    "csstype": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.9.tgz",
+      "integrity": "sha512-rpw6JPxK6Rfg1zLOYCSwle2GFOOsnjmDYDaBwEcwoOg4qlsIVCN789VkBZDJAGi4T07gI4YSutR43t9Zz4Lzuw==",
+      "dev": true
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-media-query",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Media queries for react-native and react-native-web",
   "main": "index",
   "directories": {
@@ -12,6 +12,9 @@
   },
   "dependencies": {
     "css-mediaquery": "^0.1.2"
+  },
+  "devDependencies": {
+    "@types/react-native": "^0.65.5"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Sorry, it was missing a dev dependency on @types/react-native which now fixes proper typing of the styles object, here it is below in action:

Before:
<img width="337" alt="Screenshot 2021-10-08 at 11 40 14" src="https://user-images.githubusercontent.com/23367467/136542880-9c46d1f6-d278-4e97-a966-0c50a4e25329.png">

After:
<img width="896" alt="Screenshot 2021-10-08 at 11 39 44" src="https://user-images.githubusercontent.com/23367467/136542906-c2bf3dcd-bc01-4da9-bed2-4fa3e8d0ad16.png">

