### PR TITLE
Improved typescript types for better intellisense

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2,18 +2,50 @@ import { DetailedReactHTMLElement } from "react";
 import "react-native";
 import { ImageStyle, TextStyle, ViewStyle } from "react-native";
 
+export type StyleProperty =
+  | ViewStyle
+  | TextStyle
+  | ImageStyle
+  | { [k: string]: ViewStyle | TextStyle | ImageStyle };
+
 export type NamedStyles<T> = {
-  [P in keyof T]: ViewStyle | TextStyle | ImageStyle;
+  [P in keyof T]: StyleProperty;
 };
+
+type BaseStyle<UserStyles> = {
+  [Element in keyof UserStyles]: {
+    [Property in keyof UserStyles[Element] as Property extends `@media${string}`
+      ? never
+      : Property]: UserStyles[Element][Property];
+  };
+};
+
+type ResponsiveStyle<UserStyles> = {
+  [Element in keyof UserStyles]: {
+    [P in {
+      [Property in keyof UserStyles[Element]]: Property extends `@media${string}`
+        ? {
+            [QueryProperty in keyof UserStyles[Element][Property]]: [
+              QueryProperty,
+              UserStyles[Element][Property][QueryProperty]
+            ];
+          }[keyof UserStyles[Element][Property]]
+        : never;
+    }[keyof UserStyles[Element]] as P[0]]?: P[1];
+  };
+};
+
+type ComputedStyle<UserStyles> = BaseStyle<UserStyles> &
+  ResponsiveStyle<UserStyles>;
 
 export declare function create<
   UserStyles extends NamedStyles<UserStyles> | NamedStyles<any>
 >(
   styles: UserStyles | NamedStyles<UserStyles>
 ): {
-  styles: UserStyles;
   fullStyles: UserStyles;
   ids: Record<keyof UserStyles, string>;
+  styles: ComputedStyle<UserStyles>;
 };
 
 export declare function process<

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,7 +14,9 @@ export type NamedStyles<T> = {
 
 type BaseStyle<UserStyles> = {
   [Element in keyof UserStyles]: {
-    [Property in keyof UserStyles[Element] as Property extends `@media${string}`
+    [Property in keyof UserStyles[Element] as Property extends
+      | `@media${string}`
+      | `:${string}`
       ? never
       : Property]: UserStyles[Element][Property];
   };
@@ -23,7 +25,9 @@ type BaseStyle<UserStyles> = {
 type ResponsiveStyle<UserStyles> = {
   [Element in keyof UserStyles]: {
     [P in {
-      [Property in keyof UserStyles[Element]]: Property extends `@media${string}`
+      [Property in keyof UserStyles[Element]]: Property extends
+        | `@media${string}`
+        | `:${string}`
         ? {
             [QueryProperty in keyof UserStyles[Element][Property]]: [
               QueryProperty,


### PR DESCRIPTION
I really enjoy using this library as I feel it makes working with different screen size a lot cleaner than the "original" React Native way.
However, I'm used to accessing and using individual styles properties in my components logics, rather than only in the `styles={}` tags. For this matter, having good IntelliSense make the developper experience much easier.

I modified the typescript types to get more precise typing of each style property at compile time, merging properties in queries with the associated style. Here is a little demo:

Original:
![original](https://user-images.githubusercontent.com/51379148/215221705-033707ff-451e-46ad-83f8-cc22e5dc5bfe.gif)

New:
![new](https://user-images.githubusercontent.com/51379148/215221737-627cba36-c422-4fe1-9fb8-fe4b55c398ac.gif)

